### PR TITLE
Fix GRPCUI in gRPC integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ It's needed to run gRPC server and client.
             - "8080:8080"
           volumes:
             - code:/var/www
-          entrypoint: ["grpcui", "-plaintext", "-proto", "/var/www/magento2ce/magento.proto", "-port", "8080", "-bind", "0.0.0.0", "-import-path", "/var/www/magento2ce", "app:9001"]
+          entrypoint: ["grpcui", "-plaintext", "-proto", "magento.proto", "-port", "8080", "-bind", "0.0.0.0", "-import-path", "/var/www/magento2ce", "app:9001"]
      ```
    - Make sure that paths to Magento root in entry point are correct (**/var/www/magento2ce**) - if no, replace them by correct paths.
    - Port **8080** should be opened to allow external connections to the client.

--- a/bundles/grpc.yml
+++ b/bundles/grpc.yml
@@ -139,7 +139,7 @@ services:
 #      - "8080:8080"
 #    volumes:
 #      - code:/var/www
-#    entrypoint: ["grpcui", "-plaintext", "-proto", "/var/www/magento2ce/magento.proto", "-port", "8080", "-bind", "0.0.0.0", "-import-path", "/var/www/magento2ce", "app:9001"]
+#    entrypoint: ["grpcui", "-plaintext", "-proto", "magento.proto", "-port", "8080", "-bind", "0.0.0.0", "-import-path", "/var/www/magento2ce", "app:9001"]
 
 networks:
   default:


### PR DESCRIPTION
The `-proto` argument is resolved from the provided `import-path`.